### PR TITLE
Add a Nix flake.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 zig-out/
 CLAUDE.md
 .claude/
+result

--- a/build.zig.zon2json-lock
+++ b/build.zig.zon2json-lock
@@ -1,0 +1,17 @@
+{
+  "vaxis-0.5.1-BWNV_GMyCQBtxcEkSAEb_EXbm8A24FWJFC7fXiWUVx9Y": {
+    "name": "vaxis",
+    "url": "git+https://github.com/rockorager/libvaxis#5915f33c1a7a184d3fb2aa39f087c1e6864a4308",
+    "hash": "sha256-ByPQNHaT2JtCaoSV45mXL+YA0WprXL1R7jNdYDGItHI="
+  },
+  "zigimg-0.1.0-8_eo2vUZFgAAtN1c6dAO5DdqL0d4cEWHtn6iR5ucZJti": {
+    "name": "zigimg",
+    "url": "git+https://github.com/zigimg/zigimg#eab2522c023b9259db8b13f2f90d609b7437e5f6",
+    "hash": "sha256-e42T/ZmRzuzWAhwWkcWScukcOd6rNZ1VK1wk0XGTVKs="
+  },
+  "uucode-0.1.0-ZZjBPj96QADXyt5sqwBJUnhaDYs_qBeeKijZvlRa0eqM": {
+    "name": "uucode",
+    "url": "git+https://github.com/jacobsandlund/uucode#5f05f8f83a75caea201f12cc8ea32a2d82ea9732",
+    "hash": "sha256-1Eib3ZR5xDTRHurjTL8ZWwJVKcqZtcTclxM7kcBVGGU="
+  }
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782047872,
+        "narHash": "sha256-Hqkhw0Emj7gNNQmwhF6AhZSfna9jEf4+MkEbWjHWkNQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "dbb844868c374dab5a5b0e5a666cd6970e65247a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "zig2nix": "zig2nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "zig2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1782016234,
+        "narHash": "sha256-KIDjjO7wDW503RD1TK3d4s+ilFlyiQVab3gwBlVmKRw=",
+        "owner": "Cloudef",
+        "repo": "zig2nix",
+        "rev": "334d6dff444d0a1a36e60557aba2b915e78968b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Cloudef",
+        "repo": "zig2nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,85 @@
+{
+  inputs = {
+    zig2nix.url = "github:Cloudef/zig2nix";
+  };
+
+  outputs = { zig2nix, ... }: let
+    flake-utils = zig2nix.inputs.flake-utils;
+  in (flake-utils.lib.eachDefaultSystem (system: let
+    env = zig2nix.outputs.zig-env.${system} { zig = zig2nix.outputs.packages.${system}.zig-0_15_2; };
+    pkgs = env.pkgs;
+    lib = pkgs.lib;
+  in rec {
+    # nix build .#foreign
+    # Produces clean binaries meant to be shipped outside of nix
+    packages.foreign = env.package {
+      src = lib.cleanSource ./.;
+
+      # Packages required for compiling
+      nativeBuildInputs = [];
+      # Packages required for linking
+      buildInputs = [];
+
+      zigBuildFlags = [ "-Doptimize=ReleaseFast" ];
+
+      # Smaller binaries, avoids shipping glibc
+      zigPreferMusl = true;
+
+      meta = {
+        mainProgram = "vigil";
+        description = "A clean, fast build watcher for Zig";
+        homepage = "https://github.com/chase-lambert/vigil";
+        license = lib.licenses.mit;
+        platforms = lib.platforms.linux;
+      };
+    };
+
+    # nix build .
+    packages.default = packages.foreign.override (attrs: {
+      # Prefer nix friendly settings
+      zigPreferMusl = false;
+
+      # Executables required for runtime
+      # These packages will be added to the PATH
+      zigWrapperBins = [];
+
+      # Libraries required for runtime
+      # These packages will be added to the LD_LIBRARY_PATH
+      zigWrapperLibs = attrs.buildInputs or [];
+    });
+
+    # For bundling with nix bundle for running outside of nix
+    # example: https://github.com/ralismark/nix-appimage
+    apps.bundle = {
+      type = "app";
+      program = "${packages.foreign}/bin/@SED_ZIG_BIN@";
+    };
+
+    # nix run .
+    apps.default = env.app [] "zig build run -- \"$@\"";
+
+    # nix run .#build
+    apps.build = env.app [] "zig build \"$@\"";
+
+    # nix run .#test
+    apps.test = env.app [] "zig build test -- \"$@\"";
+
+    # nix run .#docs
+    apps.docs = env.app [] "zig build docs -- \"$@\"";
+
+    # nix run .#zig2nix
+    # Use `nix run path:.#zig2nix zon2lock` to update the zon2json-lock file.
+    apps.zig2nix = env.app [] "zig2nix \"$@\"";
+
+    # nix develop
+    devShells.default = env.mkShell {
+      # Packages required for compiling, linking and running
+      # Libraries added here will be automatically added to the LD_LIBRARY_PATH and PKG_CONFIG_PATH
+      nativeBuildInputs = []
+        ++ packages.default.nativeBuildInputs
+        ++ packages.default.buildInputs
+        ++ packages.default.zigWrapperBins
+        ++ packages.default.zigWrapperLibs;
+    };
+  }));
+}


### PR DESCRIPTION
Beautiful utility, thank you for making it.

This PR allows vigil to be built and ran with ease on any Linux system via the Nix package manager, in manner of:
- `nix run github:chase-lambert/vigil`
- `nix run github:Mirsario/vigil/nix-flake` (via my fork before this is merged)

The flake is based on up-to-date templates from the zig2nix repository:
<https://github.com/Cloudef/zig2nix/tree/master/templates>

When updating the dependencies in the `build.zig.zon` file, you will unfortunately now need to run the following command to regenerate the `build.zig.zon2json-lock` file:
- `nix run .#zig2nix zon2lock`

(If you use Windows, the best way to access Nix is via WSL.)